### PR TITLE
Add ModDataChecker game feature.

### DIFF
--- a/src/moddatachecker.h
+++ b/src/moddatachecker.h
@@ -41,6 +41,13 @@ public:
    */
   virtual bool dataLooksValid(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
 
+public:
+
+  /**
+   *
+   */
+  virtual ~ModDataChecker() { }
+
 };
 
 #endif

--- a/src/moddatachecker.h
+++ b/src/moddatachecker.h
@@ -16,68 +16,6 @@ class ModDataChecker {
 public:
 
   /**
-   * @brief Enumeration indicating the severity level of information.
-   */
-  enum class ModDataSeverity {
-
-    /**
-     * @brief Used for mostly informative message that do not have impact on
-     *     the mod behavior (e.g., a .txt files in an unlikely folder).
-     */
-    INFORMATIVE,
-
-    /**
-     * @brief Used to indicate that something does not look right and might 
-     *     impact the mod behavior.
-     */
-    WARNING,
-
-    /**
-     * @brief Indicates that this mods cannot work if this issue is not fixed.
-     */
-    ERROR
-  };
-
-  /**
-   * @brief Small class encapsulating information about mod data returned by 
-   * methods from MoDataChecker.
-   *
-   */
-  class ModDataInformation {
-
-    /**
-     *
-     */
-    ModDataInformation(ModDataSeverity severity, QString message) : 
-      m_Severity(severity), m_Message(message) { }
-
-    /**
-     * @return the severity of this information.
-     */
-    ModDataSeverity severity() const { return m_Severity; }
-
-    /**
-     * @return the message corresponding to this information.
-     */
-    QString message() const { return m_Message; }
-
-  private:
-
-    ModDataSeverity m_Severity;
-    QString m_Message;
-
-  };
-
-  /**
-   *
-   */
-  enum class CheckResult {
-    VALID,
-    INVALID,
-    UNCERTAIN
-  };
-
-  /**
    * @brief The name of the data folder for the game.
    *
    * For instance, for GameBryo games it is simply "data'.
@@ -89,39 +27,19 @@ public:
   /**
    * @brief Check that the given filetree representing a valid mod layout.
    *
-   * This methods is mainly used during installation to find which installer should
-   * be used or to recurse into multi-level archives, and to quickly indicates to a 
-   * user if a mod looks valid. Heavy operations should be avoided in this method.
+   * This method is mainly used during installation (to find which installer should
+   * be used or to recurse into multi-level archives), or to quickly indicates to a 
+   * user if a mod looks valid.
+   *
+   * This method does not have to be exact, it only has to indicate if the given tree
+   * looks like a valid mod or not by quickly checking the structure (heavy operations
+   * should be avoided).
    *
    * @param tree The tree starting at the root of the "data" folder.
    *
-   * @return whether or not the tree is valid, or if it is not possible
-   *     to tell.
+   * @return whether or not the tree looks valid.
    */
-  virtual CheckResult dataLooksValid(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
-
-  /**
-   * @brief Indicates if this feature can list issues for a mod.
-   *
-   * This method indicates whether `listPotentialIssues` can be used or not.
-   *
-   * @return true if this subfeature is implemented, or false otherwize.
-   */
-  virtual bool canListPotentialIssues() const = 0;
-
-  /**
-   * @brief List potential issues with the given mod layout.
-   *
-   * If this method cannot be used (`canListPotentialIssues()` returns `false`), then an
-   * empty vector should be returned.
-   *
-   * @param tree The tree starting at the root of the "data" folder.
-   *
-   * @returns a list of information about the mod data.
-   *
-   * @see canListPotentialIssues 
-   */
-  virtual std::vector<ModDataInformation> listPotentialIssues(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
+  virtual bool dataLooksValid(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
 
 };
 

--- a/src/moddatachecker.h
+++ b/src/moddatachecker.h
@@ -2,6 +2,7 @@
 #define MODDATACHECKER_H
 
 #include <memory>
+#include <vector>
 
 #include <QString>
 
@@ -13,6 +14,59 @@ namespace MOBase {
 
 class ModDataChecker {
 public:
+
+  /**
+   * @brief Enumeration indicating the severity level of information.
+   */
+  enum class ModDataSeverity {
+
+    /**
+     * @brief Used for mostly informative message that do not have impact on
+     *     the mod behavior (e.g., a .txt files in an unlikely folder).
+     */
+    INFORMATIVE,
+
+    /**
+     * @brief Used to indicate that something does not look right and might 
+     *     impact the mod behavior.
+     */
+    WARNING,
+
+    /**
+     * @brief Indicates that this mods cannot work if this issue is not fixed.
+     */
+    ERROR
+  };
+
+  /**
+   * @brief Small class encapsulating information about mod data returned by 
+   * methods from MoDataChecker.
+   *
+   */
+  class ModDataInformation {
+
+    /**
+     *
+     */
+    ModDataInformation(ModDataSeverity severity, QString message) : 
+      m_Severity(severity), m_Message(message) { }
+
+    /**
+     * @return the severity of this information.
+     */
+    ModDataSeverity severity() const { return m_Severity; }
+
+    /**
+     * @return the message corresponding to this information.
+     */
+    QString message() const { return m_Message; }
+
+  private:
+
+    ModDataSeverity m_Severity;
+    QString m_Message;
+
+  };
 
   /**
    *
@@ -33,15 +87,41 @@ public:
   virtual QString getDataFolderName() const = 0;
 
   /**
-   * @brief Check that the given filetree representing a valid mod
-   *     layout.
+   * @brief Check that the given filetree representing a valid mod layout.
+   *
+   * This methods is mainly used during installation to find which installer should
+   * be used or to recurse into multi-level archives, and to quickly indicates to a 
+   * user if a mod looks valid. Heavy operations should be avoided in this method.
    *
    * @param tree The tree starting at the root of the "data" folder.
    *
    * @return whether or not the tree is valid, or if it is not possible
    *     to tell.
    */
-  virtual CheckResult isDataFolder(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
+  virtual CheckResult dataLooksValid(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
+
+  /**
+   * @brief Indicates if this feature can list issues for a mod.
+   *
+   * This method indicates whether `listPotentialIssues` can be used or not.
+   *
+   * @return true if this subfeature is implemented, or false otherwize.
+   */
+  virtual bool canListPotentialIssues() const = 0;
+
+  /**
+   * @brief List potential issues with the given mod layout.
+   *
+   * If this method cannot be used (`canListPotentialIssues()` returns `false`), then an
+   * empty vector should be returned.
+   *
+   * @param tree The tree starting at the root of the "data" folder.
+   *
+   * @returns a list of information about the mod data.
+   *
+   * @see canListPotentialIssues 
+   */
+  virtual std::vector<ModDataInformation> listPotentialIssues(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
 
 };
 

--- a/src/moddatachecker.h
+++ b/src/moddatachecker.h
@@ -16,15 +16,6 @@ class ModDataChecker {
 public:
 
   /**
-   * @brief The name of the data folder for the game.
-   *
-   * For instance, for GameBryo games it is simply "data'.
-   *
-   * @return the name of the data folder. 
-   */
-  virtual QString getDataFolderName() const = 0;
-
-  /**
    * @brief Check that the given filetree representing a valid mod layout.
    *
    * This method is mainly used during installation (to find which installer should

--- a/src/moddatachecker.h
+++ b/src/moddatachecker.h
@@ -1,0 +1,48 @@
+#ifndef MODDATACHECKER_H
+#define MODDATACHECKER_H
+
+#include <memory>
+
+#include <QString>
+
+namespace MOBase {
+
+  class IFileTree;
+
+};
+
+class ModDataChecker {
+public:
+
+  /**
+   *
+   */
+  enum class CheckResult {
+    VALID,
+    INVALID,
+    UNCERTAIN
+  };
+
+  /**
+   * @brief The name of the data folder for the game.
+   *
+   * For instance, for GameBryo games it is simply "data'.
+   *
+   * @return the name of the data folder. 
+   */
+  virtual QString getDataFolderName() const = 0;
+
+  /**
+   * @brief Check that the given filetree representing a valid mod
+   *     layout.
+   *
+   * @param tree The tree starting at the root of the "data" folder.
+   *
+   * @return whether or not the tree is valid, or if it is not possible
+   *     to tell.
+   */
+  virtual CheckResult isDataFolder(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
+
+};
+
+#endif


### PR DESCRIPTION
**Note:** I am just opening the PR so we can discuss the game feature and converge to a proper interface before starting to use it in other projects (installers, etc.).

The purpose of this feature is to allow per-game 'checking' of a mod data. Currently, there are only two methods:

- `getDataFolderName` - Returns the name of the data folder (e.g., `data` for Skyrim, Fallout, etc.). This can be used to recurse in archives that include the `data/` folder.

- `isDataFolder` - Check if the given tree corresponds to a valid data folder (for existing games, this corresponds to what is currently done in `InstallationTester`, that should disappear in the end).

I choose to make `isDataFolder` return an enumeration to indicate `UNCERTAIN`, not sure if this is required (one can already check for the presence of the feature).