### PR TITLE
WIP: Remove usage of ISaveGameInfoWidget.

### DIFF
--- a/src/savegameinfo.h
+++ b/src/savegameinfo.h
@@ -2,7 +2,6 @@
 #define SAVEGAMEINFO_H
 
 namespace MOBase { class ISaveGame; }
-namespace MOBase { class ISaveGameInfoWidget; }
 
 #include <QMap>
 
@@ -10,21 +9,26 @@ class QString;
 class QStringList;
 class QWidget;
 
-/** Feature to get hold of stuff to do with save games */
+/**
+ * @brief Feature to get hold of stuff to do with save games.
+ */
 class SaveGameInfo
 {
 public:
   virtual ~SaveGameInfo() {}
 
-  /** Get the information about the supplied save game */
+  using ProvidingModules = QStringList;
+  using MissingAssets = QMap<QString, ProvidingModules>;
+
+  /** 
+   * @brief Get the information about the supplied save game.
+   */
   virtual MOBase::ISaveGame const *getSaveGameInfo(QString const &file) const = 0;
 
-  typedef QStringList ProvidingModules;
-  typedef QMap<QString, ProvidingModules> MissingAssets;
-
-  /** Get items missing from save
+  /** 
+   * @brief Get items missing from save
    *
-   * @returns a collection of missing assets and the modules that can supply those
+   * @return a collection of missing assets and the modules that can supply those
    * assets.
    *
    * Note that in the situation where 'module' and 'asset' are indistinguishable,
@@ -32,19 +36,31 @@ public:
    */
   virtual MissingAssets getMissingAssets(QString const &file) const = 0;
 
-  /** Get a widget to display over the save game list.
-   *
-   * @returns a QT Widget.
-   *
-   * @param parent - parent widget
-   *
-   * It is permitted to return a null pointer to indicate you don't have a
-   * nice visual way of displaying save game contents
+  /**
+   * @return whether or not the save has a paired script extender save.
    */
-  virtual MOBase::ISaveGameInfoWidget *getSaveGameWidget(QWidget *parent = 0) const = 0;
-
-  /** Return whether or not the save has a paired script extender save */
   virtual bool hasScriptExtenderSave(QString const &file) const = 0;
+
+  /**
+   * Get a widget to display over the save game list.
+   *
+   * @param parent The parent widget.
+   *
+   * @return a QT Widget.
+   *
+   * @note It is permitted to return a null pointer to indicate you don't have a
+   * nice visual way of displaying save game contents.
+   */
+  virtual QWidget* getSaveGameWidget(QWidget* parent = 0) const = 0;
+
+  /**
+   * @brief Update the save game widget with the corresponding save.
+   *
+   * @param widget The save game widget initially returned by `getSaveGameWidget()`.
+   * @param save The save game to display in the widget.
+   *
+   */
+  virtual void updateSaveGameWidget(QWidget* widget, QString const& file) const = 0;
 };
 
 #endif // SAVEGAMEINFO_H


### PR DESCRIPTION
Note: Again, I am just opening the PR so we can discuss this.

### Problem

The root of the problem is exposing `ISaveGameInfoWidget` to python.

The `SaveGameInfo` game feature expose a `getSaveGameWidget()` which returns a  `ISaveGameInfoWidget` which is a class that extends `QWidget` and expose a `setSave` method.
After trying for a very long time to get this to work with python, I concluded that this would requires a tremendous amount of work:
- `QWidget` is "exposed" via `sip` which means it is not possible to tell `boost::python` that `ISaveGameInfoWidget` extends it (even if we have a proper converter). This means that when working with a `ISaveGameInfoWidget` (either one coming from C++, or one created by inheritance), the `QWidget` methods are not accessible. This can be workaround by exposing a `_widget()` method returning itself in C++ and then using `self._widget().method()` instead of `self.method()` in python, but...
- The ownership of `QWidget` has to be transferred from python to C++ (see, e.g., [`genFilePreview`](https://github.com/ModOrganizer2/modorganizer-plugin_python/blob/master/src/runner/proxypluginwrappers.cpp#L380)). This is possible, but it seems that once the transfer has been made, it is impossible to call python function after that (I did not manage to... ).

After a lots of research and tries, I came to the conclusion that exposing to Python classes that inherits `QWidget` would probably require wrapping them with `sip`, and even in this case, I am not sure these could be extended from python as it is required for `ISaveGameInfoWidget`. In any case, this would require a lots of work for something that can be worked around with very few changes to the feature and existing projects (see below).

### Solution

The solution I propose is to not use `ISaveGameInfoWidget` but instead work with a simple `QWidget` and transfer the `setSave` method to `SaveGameInfo`, see the proposed changes:

```cpp
virtual QWidget* getSaveGameWidget(QWidget* parent = 0) const = 0;
virtual void updateSaveGameWidget(QWidget* widget, QString const& file) const = 0;
```

What are the impact of this:
- Some very small modifications are required on the `modorganizer` project.
- Some very small modifications on the game plugins that have the `SaveGameInfo` feature. As far as I know, only `game_gamebryo` and `game_morrowind` have this.
- Removing `ISaveGameInfoWidget` from `uibase`.