### PR TITLE
Add the ModDataContent feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 std*.log
 CMakeLists.txt.user
+vsbuild

--- a/src/moddatachecker.h
+++ b/src/moddatachecker.h
@@ -13,7 +13,7 @@ class ModDataChecker {
 public:
 
   /**
-   * @brief Check that the given filetree representing a valid mod layout.
+   * @brief Check that the given filetree represent a valid mod layout.
    *
    * This method is mainly used during installation (to find which installer should
    * be used or to recurse into multi-level archives), or to quickly indicates to a 

--- a/src/moddatachecker.h
+++ b/src/moddatachecker.h
@@ -2,9 +2,6 @@
 #define MODDATACHECKER_H
 
 #include <memory>
-#include <vector>
-
-#include <QString>
 
 namespace MOBase {
 

--- a/src/moddatacontent.h
+++ b/src/moddatacontent.h
@@ -52,17 +52,47 @@ public:
      * @param icon Path to the icon for this content. Can be either a path 
      *     to an image on the disk, or to a resource.
      */
-    Content(int id, QString name, QString icon) : m_Id{ id }, m_Name { name }, m_Icon{ icon } { }
+    Content(int id, QString name, QString icon) : 
+      m_Id{ id }, m_Name{ name }, m_Icon{ icon }, m_FilterOnly{ false } { }
 
+    /**
+     * @param id ID of this content.
+     * @param name Name of this content.
+     * @param icon Path to the icon for this content. Can be either a path
+     *     to an image on the disk, or to a resource. Can be an empty string if filterOnly
+     *     is true.
+     * @param filterOnly Indicates if the content should only be show in the filter 
+     *     criteria and not in the actual Content column.
+     */
+    Content(int id, QString name, QString icon, bool filterOnly) : 
+      m_Id{ id }, m_Name{ name }, m_Icon{ icon }, m_FilterOnly{ filterOnly }  { }
+
+    /**
+     * @return the ID of this content.
+     */
     int id() const { return m_Id; }
+    
+    /**
+     * @return the name of this content.
+     */
     QString name() const { return m_Name; }
+    
+    /**
+     * @return the path to the icon of this content (can be a Qt resource path).
+     */
     QString icon() const { return m_Icon; }
   
+    /**
+     * @return true if this content is only meant to be used as a filter criteria.
+     */
+    bool isOnlyForFilter() const { return m_FilterOnly; }
+
   private:
 
     int m_Id;
     QString m_Name;
     QString m_Icon;
+    bool m_FilterOnly;
   };
 
   /**

--- a/src/moddatacontent.h
+++ b/src/moddatacontent.h
@@ -1,0 +1,76 @@
+#ifndef MODDATACONTENT_H
+#define MODDATACONTENT_H
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include <QString>
+
+namespace MOBase {
+
+  class IFileTree;
+
+};
+
+class ModDataContent {
+public:
+
+  struct Content {
+
+    /**
+     * @param id ID of this content.
+     * @param name Name of this content.
+     * @param icon Path to the icon for this content. Can be either a path 
+     *     to an image on the disk, or to a resource.
+     */
+    Content(int id, QString name, QString icon) : m_Id{ id }, m_Name { name }, m_Icon{ icon } { }
+
+    int id() const { return m_Id; }
+    QString name() const { return m_Name; }
+    QString icon() const { return m_Icon; }
+  
+  private:
+
+    int m_Id;
+    QString m_Name;
+    QString m_Icon;
+  };
+
+  /**
+   * @return the list of all possible contents for the corresponding game.
+   */
+  virtual std::vector<Content> getAllContents() const = 0;
+
+  /**
+   * @brief Retrieve the list of contents in the given tree.
+   *
+   * @param fileTree The tree corresponding to the mod to retrieve contents for.
+   *
+   * @return the IDs of the content in the given tree.
+   */
+  virtual std::vector<int> getContentsFor(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
+
+  /**
+   * @brief Check if the given tree contain the given content.
+   *
+   * @param fileTree The tree corresponding to the mod to check.
+   * @param contentId The ID of the content to lookup.
+   *
+   * @return true if the given tree contains the given content, false otherwize.
+   */
+  virtual bool hasContent(std::shared_ptr<const MOBase::IFileTree> fileTree, int contentId) const {
+    auto contents = getContentsFor(fileTree);
+    return std::find(std::begin(contents), std::end(contents), contentId) != std::end(contents);
+  }
+
+public:
+
+  /**
+   *
+   */
+  virtual ~ModDataContent() { }
+
+};
+
+#endif

--- a/src/moddatacontent.h
+++ b/src/moddatacontent.h
@@ -49,22 +49,13 @@ public:
     /**
      * @param id ID of this content.
      * @param name Name of this content.
-     * @param icon Path to the icon for this content. Can be either a path 
-     *     to an image on the disk, or to a resource.
-     */
-    Content(int id, QString name, QString icon) : 
-      m_Id{ id }, m_Name{ name }, m_Icon{ icon }, m_FilterOnly{ false } { }
-
-    /**
-     * @param id ID of this content.
-     * @param name Name of this content.
      * @param icon Path to the icon for this content. Can be either a path
      *     to an image on the disk, or to a resource. Can be an empty string if filterOnly
      *     is true.
      * @param filterOnly Indicates if the content should only be show in the filter 
      *     criteria and not in the actual Content column.
      */
-    Content(int id, QString name, QString icon, bool filterOnly) : 
+    Content(int id, QString name, QString icon, bool filterOnly = false) : 
       m_Id{ id }, m_Name{ name }, m_Icon{ icon }, m_FilterOnly{ filterOnly }  { }
 
     /**

--- a/src/moddatacontent.h
+++ b/src/moddatacontent.h
@@ -51,19 +51,6 @@ public:
    */
   virtual std::vector<int> getContentsFor(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
 
-  /**
-   * @brief Check if the given tree contain the given content.
-   *
-   * @param fileTree The tree corresponding to the mod to check.
-   * @param contentId The ID of the content to lookup.
-   *
-   * @return true if the given tree contains the given content, false otherwize.
-   */
-  virtual bool hasContent(std::shared_ptr<const MOBase::IFileTree> fileTree, int contentId) const {
-    auto contents = getContentsFor(fileTree);
-    return std::find(std::begin(contents), std::end(contents), contentId) != std::end(contents);
-  }
-
 public:
 
   /**

--- a/src/moddatacontent.h
+++ b/src/moddatacontent.h
@@ -13,6 +13,34 @@ namespace MOBase {
 
 };
 
+/**
+ * The ModDataContent feature is used (when available) to indicate to users the content
+ * of mods in the "Content" column.
+ *
+ * The feature exposes a list of possible content types, each associated with an ID, a name
+ * and an icon. The icon is the path to either:
+ *   - A Qt resource or;
+ *   - A file on the disk.
+ *
+ * In order to facilitate the implementation, MO2 already provides a set of icons that can
+ * be used. Those icons are all under :/MO/gui/content (e.g. :/MO/gui/content/plugin or :/MO/gui/content/music). 
+ *
+ * The list of available icons is:
+ *  - plugin: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/jigsaw-piece.png
+ *  - skyproc: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/hand-of-god.png
+ *  - texture: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/empty-chessboard.png
+ *  - music: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/double-quaver.png
+ *  - sound: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/lyre.png
+ *  - interface: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/usable.png
+ *  - skse: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/checkbox-tree.png
+ *  - script: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/tinker.png
+ *  - mesh: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/breastplate.png
+ *  - string: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/conversation.png
+ *  - bsa: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/locked-chest.png
+ *  - menu: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/config.png
+ *  - inifile: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/feather-and-scroll.png
+ *  - modgroup: https://github.com/ModOrganizer2/modorganizer/blob/master/src/resources/contents/xedit.png
+ */
 class ModDataContent {
 public:
 


### PR DESCRIPTION
Add a feature to replace `getContents` with a game-specific way.

Currently, an `enum` is used as the content "id", so I kept a `int`. Some thought:
- I added `hasContent` as a virtual function in the feature with a default implementation (similar to the one in `modorganizer`). This could be used if the feature can check for the presence much faster than listing.
- I used a `QString` for the icon as the icon path because it's easier to manipulate from the modorganizer side (`<img>` tag in HTML), and allow both Qt resources and files on disk.
- I thought about working with `Content*` instead of ID, so that the feature would hold a vector of `std::unique_ptr<Content>`, and then you would return `Content*` instead of `int`, but... It's easier with `int` for the python interface :P