### PR TITLE
Add possibility to fix data tree.

### DIFF
--- a/src/moddatachecker.h
+++ b/src/moddatachecker.h
@@ -13,6 +13,15 @@ class ModDataChecker {
 public:
 
   /**
+   *
+   */
+  enum class CheckReturn {
+    INVALID,
+    FIXABLE,
+    VALID
+  };
+
+  /**
    * @brief Check that the given filetree represent a valid mod layout.
    *
    * This method is mainly used during installation (to find which installer should
@@ -27,7 +36,21 @@ public:
    *
    * @return whether or not the tree looks valid.
    */
-  virtual bool dataLooksValid(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
+  virtual CheckReturn dataLooksValid(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
+
+  /**
+   * @brief Try to fix the given tree.
+   *
+   * This method is used during installation to try to fix invalid archives and will only be
+   * called if dataLooksValid returned FIXABLE.
+   *
+   * @param tree The tree to try to fix. Can be modified during the process.
+   *
+   * @return the fixed tree, or a null pointer if the tree could not be fixed.
+   */
+  virtual std::shared_ptr<MOBase::IFileTree> fix(std::shared_ptr<MOBase::IFileTree> fileTree) const {
+    return nullptr;
+  }
 
 public:
 

--- a/src/moddatachecker.h
+++ b/src/moddatachecker.h
@@ -22,7 +22,8 @@ public:
   };
 
   /**
-   * @brief Check that the given filetree represent a valid mod layout.
+   * @brief Check that the given filetree represent a valid mod layout, or can be easily
+   *   fixed.
    *
    * This method is mainly used during installation (to find which installer should
    * be used or to recurse into multi-level archives), or to quickly indicates to a 
@@ -32,9 +33,12 @@ public:
    * looks like a valid mod or not by quickly checking the structure (heavy operations
    * should be avoided).
    *
+   * If the tree can be fixed by the `fix()` method, this method should return `FIXABLE`.
+   * `FIXABLE` should only be returned when it is guaranteed that `fix()` can fix the tree.
+   *
    * @param tree The tree starting at the root of the "data" folder.
    *
-   * @return whether or not the tree looks valid.
+   * @return whether the tree is invalid, fixable or valid.
    */
   virtual CheckReturn dataLooksValid(std::shared_ptr<const MOBase::IFileTree> fileTree) const = 0;
 
@@ -42,7 +46,7 @@ public:
    * @brief Try to fix the given tree.
    *
    * This method is used during installation to try to fix invalid archives and will only be
-   * called if dataLooksValid returned FIXABLE.
+   * called if dataLooksValid returned `FIXABLE`.
    *
    * @param tree The tree to try to fix. Can be modified during the process.
    *


### PR DESCRIPTION
See https://github.com/ModOrganizer2/modorganizer/issues/1129

This allows implementation to provide a way to fix a tree. I had to change `dataLooksValid`:

- If `dataLooksValid` does not indicate if the tree can be fixed, we would have to call a `tryFix`.
- The `isArhiveSupported` method takes a const-`IFileTree`, so it cannot be modified, and so `tryFix` cannot really be used.

This way requires changes to other projects but it's cleaner in my opinion.