### PR TITLE
Change getLoadOrder()

### DIFF
--- a/src/gameplugins.h
+++ b/src/gameplugins.h
@@ -14,7 +14,7 @@ public:
 
   virtual void writePluginLists(const MOBase::IPluginList *pluginList) = 0;
   virtual void readPluginLists(MOBase::IPluginList *pluginList) = 0;
-  virtual void getLoadOrder(QStringList &loadOrder) = 0;
+  virtual QStringList getLoadOrder() = 0;
   virtual bool lightPluginsAreSupported() = 0;
 
 };


### PR DESCRIPTION
Makes `getLoadOrder()` return the load order instead of updating the passed reference.